### PR TITLE
Km/clean up express routes

### DIFF
--- a/client/components/all-songs.js
+++ b/client/components/all-songs.js
@@ -16,14 +16,14 @@ class Songs extends Component {
     this.props.loadSongs()
     this.props.loadCart()
   }
-  handleClick(event) {
-    console.log('EVENT', event)
-    this.props.addSong(event)
+  handleClick(songId, mixtapeId) {
+    this.props.addSong(songId, mixtapeId)
     this.props.loadCart()
   }
 
   render() {
     const songs = this.props.songs
+    const currentMixtape = this.props.cart[0]
     return (
       <Container fluid="md">
         <CardColumns>
@@ -41,7 +41,9 @@ class Songs extends Component {
                   variant="secondary"
                   type="submit"
                   className="add-song"
-                  onClick={() => this.handleClick(song.id)}
+                  onClick={(songId, mixtapeId) =>
+                    this.handleClick(song.id, currentMixtape.id)
+                  }
                 >
                   <i className="fas fa-cart-plus" />
                 </Button>
@@ -58,14 +60,15 @@ class Songs extends Component {
  * CONTAINER
  */
 const mapState = state => ({
-  songs: state.songs
+  songs: state.songs,
+  cart: state.cartReducer
 })
 
 const mapDispatch = dispatch => {
   return {
     loadSongs: () => dispatch(fetchSongs()),
     loadCart: () => dispatch(fetchCart()),
-    addSong: id => dispatch(addSongToCart(id))
+    addSong: (songId, mixtapeId) => dispatch(addSongToCart(songId, mixtapeId))
   }
 }
 

--- a/client/components/all-songs.js
+++ b/client/components/all-songs.js
@@ -41,9 +41,7 @@ class Songs extends Component {
                   variant="secondary"
                   type="submit"
                   className="add-song"
-                  onClick={(songId, mixtapeId) =>
-                    this.handleClick(song.id, currentMixtape.id)
-                  }
+                  onClick={() => this.handleClick(song.id, currentMixtape.id)}
                 >
                   <i className="fas fa-cart-plus" />
                 </Button>

--- a/client/components/single-song.js
+++ b/client/components/single-song.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import {fetchSingleSong} from '../store/single_song'
-import {addSongToCart} from '../store/cart'
+import {addSongToCart, fetchCart} from '../store/cart'
 import {Container, Row, Card, Col, Accordion, Button} from 'react-bootstrap'
 
 class Single_Song extends React.Component {
@@ -13,18 +13,20 @@ class Single_Song extends React.Component {
   componentDidMount() {
     try {
       this.props.fetchSingleSong(this.props.match.params.songId)
+      this.props.loadCart()
     } catch (error) {
       console.log('I hate this song', error)
     }
   }
 
-  handleClick(event) {
-    console.log('EVENT', event)
-    this.props.addSong(event)
+  handleClick(songId, mixtapeId) {
+    this.props.addSong(songId, mixtapeId)
+    this.props.loadCart()
   }
 
   render() {
     const song = this.props.song
+    const currentMixtape = this.props.cart[0]
     return (
       <Container>
         <Row>
@@ -51,7 +53,9 @@ class Single_Song extends React.Component {
                   variant="secondary"
                   type="submit"
                   className="add-song"
-                  onClick={() => this.handleClick(song.id)}
+                  onClick={(songId, mixtapeId) =>
+                    this.handleClick(song.id, currentMixtape.id)
+                  }
                 >
                   <i className="fas fa-cart-plus" />
                 </Button>
@@ -90,14 +94,16 @@ class Single_Song extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    song: state.single_song
+    song: state.single_song,
+    cart: state.cartReducer
   }
 }
 
 const mapDispatchToProps = dispatch => {
   return {
     fetchSingleSong: id => dispatch(fetchSingleSong(id)),
-    addSong: id => dispatch(addSongToCart(id))
+    loadCart: () => dispatch(fetchCart()),
+    addSong: (songId, mixtapeId) => dispatch(addSongToCart(songId, mixtapeId))
   }
 }
 

--- a/client/components/single-song.js
+++ b/client/components/single-song.js
@@ -53,9 +53,7 @@ class Single_Song extends React.Component {
                   variant="secondary"
                   type="submit"
                   className="add-song"
-                  onClick={(songId, mixtapeId) =>
-                    this.handleClick(song.id, currentMixtape.id)
-                  }
+                  onClick={() => this.handleClick(song.id, currentMixtape.id)}
                 >
                   <i className="fas fa-cart-plus" />
                 </Button>

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -26,10 +26,10 @@ export const setMixtapeName = name => ({
   name
 })
 
-export const addSong = (songId, newSong) => ({
+export const addSong = (newSong, mixtapeId) => ({
   type: ADD_SONG,
-  songId,
-  newSong
+  newSong,
+  mixtapeId
 })
 
 export const deleteSong = songId => ({
@@ -50,11 +50,11 @@ export const fetchCart = () => {
   }
 }
 
-export const addSongToCart = songId => {
+export const addSongToCart = (songId, mixtapeId) => {
   return async dispatch => {
     const newSong = await axios.get(`/api/songs/${songId}`)
     await axios.put(`/api/songs/add/${songId}`, newSong.data)
-    dispatch(addSong(songId, newSong.data))
+    dispatch(addSong(newSong.data, mixtapeId))
   }
 }
 
@@ -94,13 +94,16 @@ const cartReducer = (state = initialState, action) => {
     case SET_MIXTAPE_NAME:
       return {...state, name: action.setMixtapeName}
     case ADD_SONG:
-      // console.log("STATE-->", state.songs)
-      return {...state, songs: [...state.songs, action.newSong]}
+      state.map(mixtape => {
+        if ((mixtape.id = action.mixtapeId)) {
+          return [{...mixtape, songs: [...mixtape.songs, action.newSong]}]
+        }
+      })
     case DELETE_SONG_FROM_CART:
-      const remainingSongs = state.songs.filter(
-        song => song.id !== action.songId
-      )
-      return {...state, songs: remainingSongs}
+    // const remainingSongs = state.songs.filter(
+    //   song => song.id !== action.songId
+    // )
+    // return { ...state, songs: remainingSongs }
     case SET_LOCAL_STORAGE:
       return [...state]
     default:

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -100,10 +100,10 @@ const cartReducer = (state = initialState, action) => {
         }
       })
     case DELETE_SONG_FROM_CART:
-    // const remainingSongs = state.songs.filter(
-    //   song => song.id !== action.songId
-    // )
-    // return { ...state, songs: remainingSongs }
+      const remainingSongs = state.songs.filter(
+        song => song.id !== action.songId
+      )
+      return {...state, songs: remainingSongs}
     case SET_LOCAL_STORAGE:
       return [...state]
     default:

--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -12,12 +12,14 @@ router.get('/', async (req, res, next) => {
           fulfilled: false
         },
         include: {model: Mixtape, include: Song}
-      }).then(result => {
-        return result.mixtapes.map(mixtape => {
-          return mixtape.get()
-        })
       })
-      res.send(order)
+      const mixtape = await Mixtape.findAll({
+        where: {
+          orderId: order.id
+        },
+        include: Song
+      })
+      res.send(mixtape)
     } else if (!req.user) {
       res.send(401)
     }


### PR DESCRIPTION
What I did

* [x] Fixed the cart .get route. No more '.then' being used to grab our mixtape array
* [x] Restructured our ADD_SONGS reducer to fix our bug when adding songs to the cart


Note: I could only figure out how to successfully fix these items by assuming the user will only have one 'unfulfilled' order at a time in their mixtapes array. If we decide to add functionality that allows them to open more active mixtapes, we will need to reassess how to update these routes/reducers.